### PR TITLE
Add .strz as primary file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
           "structurizr"
         ],
         "extensions": [
+          ".strz",
           ".dsl"
         ],
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
## Summary
- Registers `.strz` as the primary file extension for Structurizr DSL files
- Keeps `.dsl` for backward compatibility with official Structurizr tooling

## Test plan
- [ ] Open a `.strz` file — verify syntax highlighting, completions, and preview work
- [ ] Open a `.dsl` file — verify it still gets full language support

🤖 Generated with [Claude Code](https://claude.com/claude-code)