### PR TITLE
Add CI workflow for PR test gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run compile
+
+      - run: xvfb-run npm test


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs on all PRs targeting `main`
- Compiles TypeScript and runs VS Code extension tests via `xvfb-run`
- Once merged, branch protection will be configured to require this check to pass before merging

## Test plan
- [ ] Verify the CI check runs on this PR itself
- [ ] After merge, configure branch protection to require the `test` status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)